### PR TITLE
Improve yamux performance

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -17,6 +17,7 @@ import (
 var clientHostPort int
 var clientServerToClientBufSize uint
 var clientYamux bool
+var clientYamuxBufSize uint
 var clientSymmetricallyEncrypts bool
 var clientSymmetricallyEncryptPassphrase string
 var clientCipherType string
@@ -26,6 +27,7 @@ func init() {
 	clientCmd.Flags().IntVarP(&clientHostPort, "port", "p", 0, "TCP port of client host")
 	clientCmd.Flags().UintVarP(&clientServerToClientBufSize, "s-to-c-buf-size", "", 16, "Buffer size of server-to-client in bytes")
 	clientCmd.Flags().BoolVarP(&clientYamux, yamuxFlagLongName, "", false, "Multiplex connection by hashicorp/yamux")
+	clientCmd.Flags().UintVarP(&clientYamuxBufSize, "yamux-buf-size", "", 4096, "yamux buffer size in bytes")
 	clientCmd.Flags().BoolVarP(&clientSymmetricallyEncrypts, symmetricallyEncryptsFlagLongName, symmetricallyEncryptsFlagShortName, false, "Encrypt symmetrically")
 	clientCmd.Flags().StringVarP(&clientSymmetricallyEncryptPassphrase, symmetricallyEncryptPassphraseFlagLongName, "", "", "Passphrase for encryption")
 	clientCmd.Flags().StringVarP(&clientCipherType, cipherTypeFlagLongName, "", defaultCipherType, fmt.Sprintf("Cipher type: %s, %s", cipherTypeAesCtr, cipherTypeOpenpgp))
@@ -216,14 +218,12 @@ func clientHandleWithYamux(ln net.Listener, httpClient *http.Client, headers []p
 		}
 		fin := make(chan struct{})
 		go func() {
-			// TODO: hard code
-			var buf = make([]byte, 16)
+			var buf = make([]byte, clientYamuxBufSize)
 			io.CopyBuffer(yamuxStream, conn, buf)
 			fin <- struct{}{}
 		}()
 		go func() {
-			// TODO: hard code
-			var buf = make([]byte, 16)
+			var buf = make([]byte, clientYamuxBufSize)
 			io.CopyBuffer(conn, yamuxStream, buf)
 			fin <- struct{}{}
 		}()

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -17,6 +17,7 @@ import (
 var serverHostPort int
 var serverClientToServerBufSize uint
 var serverYamux bool
+var serverYamuxBufSize uint
 var serverSymmetricallyEncrypts bool
 var serverSymmetricallyEncryptPassphrase string
 var serverCipherType string
@@ -27,6 +28,7 @@ func init() {
 	serverCmd.MarkFlagRequired("port")
 	serverCmd.Flags().UintVarP(&serverClientToServerBufSize, "c-to-s-buf-size", "", 16, "Buffer size of client-to-server in bytes")
 	serverCmd.Flags().BoolVarP(&serverYamux, yamuxFlagLongName, "", false, "Multiplex connection by hashicorp/yamux")
+	serverCmd.Flags().UintVarP(&serverYamuxBufSize, "yamux-buf-size", "", 4096, "yamux buffer size in bytes")
 	serverCmd.Flags().BoolVarP(&serverSymmetricallyEncrypts, symmetricallyEncryptsFlagLongName, symmetricallyEncryptsFlagShortName, false, "Encrypt symmetrically")
 	serverCmd.Flags().StringVarP(&serverSymmetricallyEncryptPassphrase, symmetricallyEncryptPassphraseFlagLongName, "", "", "Passphrase for encryption")
 	serverCmd.Flags().StringVarP(&serverCipherType, cipherTypeFlagLongName, "", defaultCipherType, fmt.Sprintf("Cipher type: %s, %s", cipherTypeAesCtr, cipherTypeOpenpgp))
@@ -201,14 +203,12 @@ func serverHandleWithYamux(httpClient *http.Client, headers []piping_tunnel_util
 		}
 		fin := make(chan struct{})
 		go func() {
-			// TODO: hard code
-			var buf = make([]byte, 16)
+			var buf = make([]byte, serverYamuxBufSize)
 			io.CopyBuffer(yamuxStream, conn, buf)
 			fin <- struct{}{}
 		}()
 		go func() {
-			// TODO: hard code
-			var buf = make([]byte, 16)
+			var buf = make([]byte, serverYamuxBufSize)
 			io.CopyBuffer(conn, yamuxStream, buf)
 			fin <- struct{}{}
 		}()


### PR DESCRIPTION
Bumps up the buffer size when using yamux from 16 bytes to 4096 by
default and adds an option for the user to specify a specific buffer
size.

In local testing, bumping the buffer size from 16 bytes to 4096 improved
the scp file copy speed from ~1MB/s to ~50MB/s, and doesn't seem to have
any negative impact on interaction interactions.